### PR TITLE
feature: null safe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '1.20.4'
-          channel: 'stable'
+          flutter-version: '1.24.0-10.2.pre'
+          channel: 'beta'
       - run: flutter pub get
       - run: flutter test
 
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '1.20.4'
-          channel: 'stable'
+          flutter-version: '1.24.0-10.2.pre'
+          channel: 'beta'
       - run: flutter pub get
       - run: flutter analyze
 
@@ -38,6 +38,6 @@ jobs:
       - uses: actions/checkout@v1
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '1.20.4'
-          channel: 'stable'
+          flutter-version: '1.24.0-10.2.pre'
+          channel: 'beta'
       - run: flutter format . --set-exit-if-changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.0-nullsafety.0]
+
+* Migrate to null safety
+
 ## [1.0.0]
 
 * Documentation updates, stable release

--- a/lib/src/api_logger.dart
+++ b/lib/src/api_logger.dart
@@ -7,4 +7,4 @@ class ApiLogger {
   static List<OnError> onErrorMiddleware = [];
 }
 
-typedef OnError = Function(String message, Exception e, StackTrace stack);
+typedef OnError = Function(String message, Object? e, StackTrace? stack);

--- a/lib/src/api_logger.dart
+++ b/lib/src/api_logger.dart
@@ -7,4 +7,4 @@ class ApiLogger {
   static List<OnError> onErrorMiddleware = [];
 }
 
-typedef OnError = Function(String message, Object? e, StackTrace? stack);
+typedef OnError = Function(String message, Exception? e, StackTrace? stack);

--- a/lib/src/api_response.dart
+++ b/lib/src/api_response.dart
@@ -6,12 +6,12 @@ class ApiResponse<T> {
   final int statusCode;
 
   /// Response data transformed into a strongly typed object
-  final T data;
+  final T? data;
 
   /// Only populated when the request fails for some reason. This value will
   /// contain an error response from the server or exception information if
   /// the request failed before getting a response.
-  final String error;
+  final String? error;
 
   /// If the request was successful
   bool get isSuccess => isSuccessStatusCode(statusCode);

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -186,20 +186,15 @@ ApiResponse<T> _handleResult<T>(
   T Function(Map<String, dynamic>)? fromJson,
   bool useFromJsonOnFailure,
 ) {
-  final body = jsonDecode(response.body);
   T? data;
-  if (!(body is Map<String, dynamic>)) {
-    _onError(method, url, response.statusCode, response.body);
-    return ApiResponse(response.statusCode, error: response.body);
-  }
   if (isSuccessStatusCode(response.statusCode)) {
     if (fromJson != null) {
-      data = fromJson(body);
+      data = fromJson(jsonDecode(response.body) as Map<String, dynamic>);
     }
     return ApiResponse<T>(response.statusCode, data: data);
   } else {
     if (fromJson != null && useFromJsonOnFailure) {
-      data = fromJson(body);
+      data = fromJson(jsonDecode(response.body) as Map<String, dynamic>);
     }
     _onError(method, url, response.statusCode, response.body);
     return ApiResponse(response.statusCode, data: data, error: response.body);

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -226,8 +226,8 @@ ApiResponse<List<T>> _handleListResult<T>(
   T Function(Map<String, dynamic>) fromJson,
 ) {
   if (isSuccessStatusCode(response.statusCode)) {
-    var list = json.decode(response.body) as Iterable;
-    var data = list.map((x) => fromJson(x as Map<String, dynamic>)).toList();
+    final list = json.decode(response.body) as Iterable;
+    final data = list.map((x) => fromJson(x as Map<String, dynamic>)).toList();
     return ApiResponse<List<T>>(response.statusCode, data: data);
   } else {
     _onError(method, url, response.statusCode, response.body);

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -15,7 +15,9 @@ void setHttpClientForTesting(http.Client client) {
 
 http.Client _client = http.Client();
 
-const Map<String, String> defaultHeaders = {'Content-Type': 'application/json'};
+const Map<String, String> _defaultHeaders = {
+  'Content-Type': 'application/json'
+};
 
 typedef FromJson<T> = T Function(Map<String, dynamic>);
 
@@ -24,7 +26,7 @@ Future<ApiResponse<T>> get<T>(
     {required String url,
     required FromJson<T> fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers = defaultHeaders}) async {
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response = await _client.get(url, headers: headers);
     return _handleResult('GET', url, response, fromJson, useFromJsonOnFailure);
@@ -36,7 +38,8 @@ Future<ApiResponse<T>> get<T>(
 
 /// Make a GET request with a byte array response
 Future<ApiResponse<Uint8List>> getByteArray(
-    {required String url, Map<String, String> headers = defaultHeaders}) async {
+    {required String url,
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response = await _client.get(url, headers: headers);
     return _handleByteArrayResult('GET', url, response);
@@ -50,7 +53,7 @@ Future<ApiResponse<Uint8List>> getByteArray(
 Future<ApiResponse<List<T>>> getList<T>(
     {required String url,
     required FromJson<T> fromJson,
-    Map<String, String> headers = defaultHeaders}) async {
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response = await _client.get(url, headers: headers);
     return _handleListResult('GET', url, response, fromJson);
@@ -67,7 +70,7 @@ Future<ApiResponse<T>> post<T>(
     required Map<String, dynamic> body,
     FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers = defaultHeaders}) async {
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response =
         await _client.post(url, headers: headers, body: jsonEncode(body));
@@ -85,7 +88,7 @@ Future<ApiResponse<T>> postAsString<T>(
     required String body,
     FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers = defaultHeaders}) async {
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response = await _client.post(url, headers: headers, body: body);
     return _handleResult('POST', url, response, fromJson, useFromJsonOnFailure);
@@ -101,7 +104,7 @@ Future<ApiResponse<List<T>>> postAndGetList<T>(
     {required String url,
     required Map<String, dynamic> body,
     required FromJson<T> fromJson,
-    Map<String, String> headers = defaultHeaders}) async {
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response =
         await _client.post(url, headers: headers, body: jsonEncode(body));
@@ -119,7 +122,7 @@ Future<ApiResponse<T>> put<T>(
     required Map<String, dynamic> body,
     FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers = defaultHeaders}) async {
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response =
         await _client.put(url, headers: headers, body: jsonEncode(body));
@@ -137,7 +140,7 @@ Future<ApiResponse<T>> putList<T>(
     required List body,
     FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers = defaultHeaders}) async {
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response =
         await _client.put(url, headers: headers, body: jsonEncode(body));
@@ -150,7 +153,8 @@ Future<ApiResponse<T>> putList<T>(
 
 /// Make a DELETE request
 Future<ApiResponse<T>> delete<T>(
-    {required String url, Map<String, String> headers = defaultHeaders}) async {
+    {required String url,
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response = await _client.delete(url, headers: headers);
     return _handleResult('DELETE', url, response, null, false);
@@ -167,7 +171,7 @@ Future<ApiResponse<T>> patch<T>(
     required Map<String, dynamic> body,
     FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers = defaultHeaders}) async {
+    Map<String, String> headers = _defaultHeaders}) async {
   try {
     var response =
         await _client.patch(url, headers: headers, body: jsonEncode(body));

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -27,7 +27,7 @@ Future<ApiResponse<T>> get<T>(
   try {
     var response = await _client.get(url, headers: headers);
     return _handleResult('GET', url, response, fromJson, useFromJsonOnFailure);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('GET', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -39,7 +39,7 @@ Future<ApiResponse<Uint8List>> getByteArray(
   try {
     var response = await _client.get(url, headers: headers);
     return _handleByteArrayResult('GET', url, response);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('GET', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -53,7 +53,7 @@ Future<ApiResponse<List<T>>> getList<T>(
   try {
     var response = await _client.get(url, headers: headers);
     return _handleListResult('GET', url, response, fromJson);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('GET', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -71,7 +71,7 @@ Future<ApiResponse<T>> post<T>(
     var response =
         await _client.post(url, headers: headers, body: jsonEncode(body));
     return _handleResult('POST', url, response, fromJson, useFromJsonOnFailure);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('POST', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -88,7 +88,7 @@ Future<ApiResponse<T>> postAsString<T>(
   try {
     var response = await _client.post(url, headers: headers, body: body);
     return _handleResult('POST', url, response, fromJson, useFromJsonOnFailure);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('POST', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -105,7 +105,7 @@ Future<ApiResponse<List<T>>> postAndGetList<T>(
     var response =
         await _client.post(url, headers: headers, body: jsonEncode(body));
     return _handleListResult('POST', url, response, fromJson);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('POST', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -123,7 +123,7 @@ Future<ApiResponse<T>> put<T>(
     var response =
         await _client.put(url, headers: headers, body: jsonEncode(body));
     return _handleResult('PUT', url, response, fromJson, useFromJsonOnFailure);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('PUT', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -141,7 +141,7 @@ Future<ApiResponse<T>> putList<T>(
     var response =
         await _client.put(url, headers: headers, body: jsonEncode(body));
     return _handleResult('PUT', url, response, fromJson, useFromJsonOnFailure);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('PUT', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -153,7 +153,7 @@ Future<ApiResponse<T>> delete<T>(
   try {
     var response = await _client.delete(url, headers: headers);
     return _handleResult('DELETE', url, response, null, false);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('DELETE', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -172,7 +172,7 @@ Future<ApiResponse<T>> patch<T>(
         await _client.patch(url, headers: headers, body: jsonEncode(body));
     return _handleResult(
         'PATCH', url, response, fromJson, useFromJsonOnFailure);
-  } catch (e, stack) {
+  } on Exception catch (e, stack) {
     _onException('PATCH', url, -1, e, stack);
     return ApiResponse(-1, error: e.toString());
   }
@@ -235,7 +235,7 @@ void _onException(
   String method,
   String url,
   int statusCode, [
-  Object? e,
+  Exception? e,
   StackTrace? stack,
 ]) {
   var message = 'Api Error: $statusCode $method $url Error: ${e.toString()}';

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -207,10 +207,12 @@ ApiResponse<Uint8List> _handleByteArrayResult(
   http.Response response,
 ) {
   if (isSuccessStatusCode(response.statusCode)) {
-    return ApiResponse<Uint8List>(response.statusCode, data: response.bodyBytes);
+    return ApiResponse<Uint8List>(response.statusCode,
+        data: response.bodyBytes);
   } else {
     _onError(method, url, response.statusCode, response.body);
-    return ApiResponse(response.statusCode, data: response.bodyBytes, error: response.body);
+    return ApiResponse(response.statusCode,
+        data: response.bodyBytes, error: response.body);
   }
 }
 

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -10,7 +10,6 @@ import 'package:api_utils/src/api_response.dart';
 
 @visibleForTesting
 void setHttpClientForTesting(http.Client client) {
-  assert(client != null);
   _client = client;
 }
 

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'dart:convert';
 
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:api_utils/src/api_logger.dart';
@@ -15,14 +16,14 @@ void setHttpClientForTesting(http.Client client) {
 
 http.Client _client = http.Client();
 
-typedef FromJson<T> = T Function(Map<String, dynamic>);
+typedef FromJson<T> = T Function(Map<String, dynamic>?);
 
 /// Make a GET request with a json object response
 Future<ApiResponse<T>> get<T>(
-    {@required String url,
-    @required FromJson<T> fromJson,
+    {required String url,
+    required FromJson<T> fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers}) async {
+    required Map<String, String> headers}) async {
   try {
     var response = await _client.get(url, headers: headers);
     return _handleResult('GET', url, response, fromJson, useFromJsonOnFailure);
@@ -34,7 +35,7 @@ Future<ApiResponse<T>> get<T>(
 
 /// Make a GET request with a byte array response
 Future<ApiResponse<Uint8List>> getByteArray(
-    {@required String url, Map<String, String> headers}) async {
+    {required String url, required Map<String, String> headers}) async {
   try {
     var response = await _client.get(url, headers: headers);
     return _handleByteArrayResult('GET', url, response);
@@ -46,9 +47,9 @@ Future<ApiResponse<Uint8List>> getByteArray(
 
 /// Make a GET request with an json list response
 Future<ApiResponse<List<T>>> getList<T>(
-    {@required String url,
-    @required FromJson<T> fromJson,
-    Map<String, String> headers}) async {
+    {required String url,
+    required FromJson<T> fromJson,
+    required Map<String, String> headers}) async {
   try {
     var response = await _client.get(url, headers: headers);
     return _handleListResult('GET', url, response, fromJson);
@@ -61,11 +62,11 @@ Future<ApiResponse<List<T>>> getList<T>(
 /// Make a POST request sending a json object, with an optional json object
 /// response
 Future<ApiResponse<T>> post<T>(
-    {@required String url,
-    @required Map<String, dynamic> body,
-    FromJson<T> fromJson,
+    {required String url,
+    required Map<String, dynamic> body,
+    FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers}) async {
+    required Map<String, String> headers}) async {
   try {
     var response =
         await _client.post(url, headers: headers, body: jsonEncode(body));
@@ -79,11 +80,11 @@ Future<ApiResponse<T>> post<T>(
 /// Make a POST request sending a raw string, with an optional json object
 /// response
 Future<ApiResponse<T>> postAsString<T>(
-    {@required String url,
-    @required String body,
-    FromJson<T> fromJson,
+    {required String url,
+    required String body,
+    FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers}) async {
+    required Map<String, String> headers}) async {
   try {
     var response = await _client.post(url, headers: headers, body: body);
     return _handleResult('POST', url, response, fromJson, useFromJsonOnFailure);
@@ -96,10 +97,10 @@ Future<ApiResponse<T>> postAsString<T>(
 /// Make a POST request sending a json object, with an optional json list
 /// response
 Future<ApiResponse<List<T>>> postAndGetList<T>(
-    {@required String url,
-    @required Map<String, dynamic> body,
-    @required FromJson<T> fromJson,
-    Map<String, String> headers}) async {
+    {required String url,
+    required Map<String, dynamic> body,
+    required FromJson<T> fromJson,
+    required Map<String, String> headers}) async {
   try {
     var response =
         await _client.post(url, headers: headers, body: jsonEncode(body));
@@ -113,11 +114,11 @@ Future<ApiResponse<List<T>>> postAndGetList<T>(
 /// Make a PUT request sending a json object, with an optional json object
 /// response
 Future<ApiResponse<T>> put<T>(
-    {@required String url,
-    @required Map<String, dynamic> body,
-    FromJson<T> fromJson,
+    {required String url,
+    required Map<String, dynamic> body,
+    FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers}) async {
+    required Map<String, String> headers}) async {
   try {
     var response =
         await _client.put(url, headers: headers, body: jsonEncode(body));
@@ -131,11 +132,11 @@ Future<ApiResponse<T>> put<T>(
 /// Make a PUT request sending a json list, with an optional json object
 /// response
 Future<ApiResponse<T>> putList<T>(
-    {@required String url,
-    @required List body,
-    FromJson<T> fromJson,
+    {required String url,
+    required List body,
+    FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers}) async {
+    required Map<String, String> headers}) async {
   try {
     var response =
         await _client.put(url, headers: headers, body: jsonEncode(body));
@@ -148,7 +149,7 @@ Future<ApiResponse<T>> putList<T>(
 
 /// Make a DELETE request
 Future<ApiResponse<T>> delete<T>(
-    {@required String url, Map<String, String> headers}) async {
+    {required String url, required Map<String, String> headers}) async {
   try {
     var response = await _client.delete(url, headers: headers);
     return _handleResult('DELETE', url, response, null, false);
@@ -161,11 +162,11 @@ Future<ApiResponse<T>> delete<T>(
 /// Make a PATCH request sending a json object, with an optional json object
 /// response
 Future<ApiResponse<T>> patch<T>(
-    {@required String url,
-    @required Map<String, dynamic> body,
-    FromJson<T> fromJson,
+    {required String url,
+    required Map<String, dynamic> body,
+    FromJson<T>? fromJson,
     bool useFromJsonOnFailure = false,
-    Map<String, String> headers}) async {
+    required Map<String, String> headers}) async {
   try {
     var response =
         await _client.patch(url, headers: headers, body: jsonEncode(body));
@@ -181,18 +182,18 @@ ApiResponse<T> _handleResult<T>(
   String method,
   String url,
   http.Response response,
-  T Function(Map<String, dynamic>) fromJson,
+  T Function(Map<String, dynamic>?)? fromJson,
   bool useFromJsonOnFailure,
 ) {
-  T data;
+  T? data;
   if (isSuccessStatusCode(response.statusCode)) {
     if (fromJson != null) {
-      data = fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+      data = fromJson(jsonDecode(response.body) as Map<String, dynamic>?);
     }
     return ApiResponse<T>(response.statusCode, data: data);
   } else {
     if (fromJson != null && useFromJsonOnFailure) {
-      data = fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+      data = fromJson(jsonDecode(response.body) as Map<String, dynamic>?);
     }
     _onError(method, url, response.statusCode, response.body);
     return ApiResponse(response.statusCode, data: data, error: response.body);
@@ -204,7 +205,7 @@ ApiResponse<Uint8List> _handleByteArrayResult(
   String url,
   http.Response response,
 ) {
-  Uint8List data;
+  Uint8List? data;
   if (isSuccessStatusCode(response.statusCode)) {
     data = response.bodyBytes;
     return ApiResponse<Uint8List>(response.statusCode, data: data);
@@ -234,11 +235,11 @@ void _onException(
   String method,
   String url,
   int statusCode, [
-  Exception e,
-  StackTrace stack,
+  Object? e,
+  StackTrace? stack,
 ]) {
   var message = 'Api Error: $statusCode $method $url Error: ${e.toString()}';
-  ApiLogger.onErrorMiddleware?.forEach((x) => {x(message, e, stack)});
+  ApiLogger.onErrorMiddleware.forEach((x) => {x(message, e, stack)});
 }
 
 void _onError(
@@ -248,5 +249,5 @@ void _onError(
   String error,
 ) {
   var message = 'Api Error: $statusCode $method $url Error: $error';
-  ApiLogger.onErrorMiddleware?.forEach((x) => {x(message, null, null)});
+  ApiLogger.onErrorMiddleware.forEach((x) => {x(message, null, null)});
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,28 +80,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.6"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.3"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,56 +113,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.5"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0-29.10.beta <3.0.0"
   flutter: ">=1.17.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: api_utils
 description: Convenient api utilities to make working with REST APIs easier
-version: 1.0.0
+version: 2.0.0-nullsafety.0
 homepage: https://github.com/HomeXLabs/api_utils
 repository: https://github.com/HomeXLabs/api_utils
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/HomeXLabs/api_utils
 repository: https://github.com/HomeXLabs/api_utils
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0-29.10.beta <3.0.0'
   flutter: ">=1.17.0 <2.0.0"
 
 dependencies:

--- a/test/api_utils_test.dart
+++ b/test/api_utils_test.dart
@@ -35,8 +35,7 @@ void main() {
   test('getList', () async {
     var response = await getList(
         url: 'https://jsonplaceholder.typicode.com/posts',
-        fromJson: (x) => Post.fromJson(x),
-        headers: {});
+        fromJson: (x) => Post.fromJson(x));
 
     expect(response.statusCode, 200);
     expect(response.isSuccess, true);
@@ -51,8 +50,7 @@ void main() {
 
     var response = await getList(
         url: 'https://jsonplaceholder.typicode.com/posts-bad-url',
-        fromJson: (x) => Post.fromJson(x),
-        headers: {});
+        fromJson: (x) => Post.fromJson(x));
 
     expect(response.statusCode, 404);
     expect(response.isSuccess, false);
@@ -64,8 +62,7 @@ void main() {
     var newPost = Post(title: 'title', body: 'body');
     var response = await post(
         url: 'https://jsonplaceholder.typicode.com/posts',
-        body: newPost.toJson(),
-        headers: {});
+        body: newPost.toJson());
 
     expect(response.statusCode, 201);
     expect(response.isSuccess, true);

--- a/test/api_utils_test.dart
+++ b/test/api_utils_test.dart
@@ -1,3 +1,4 @@
+// @dart=2.9
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -34,7 +35,7 @@ void main() {
   test('getList', () async {
     var response = await getList(
       url: 'https://jsonplaceholder.typicode.com/posts',
-      fromJson: (x) => Post.fromJson(x!),
+      fromJson: (x) => Post.fromJson(x),
       headers: {}
     );
 
@@ -44,14 +45,14 @@ void main() {
   });
 
   test('ApiLogger logs', () async {
-    String? errorMsg;
+    String errorMsg;
     ApiLogger.onErrorMiddleware.add((message, e, stack) {
       errorMsg = message;
     });
 
     var response = await getList(
       url: 'https://jsonplaceholder.typicode.com/posts-bad-url',
-      fromJson: (x) => Post.fromJson(x!),
+      fromJson: (x) => Post.fromJson(x),
       headers: {}
     );
 
@@ -82,10 +83,10 @@ class Post {
     this.body,
   });
 
-  final int? userId;
-  final int? id;
-  final String? title;
-  final String? body;
+  final int userId;
+  final int id;
+  final String title;
+  final String body;
 
   factory Post.fromJson(Map<String, dynamic> json) => Post(
         userId: json["userId"],

--- a/test/api_utils_test.dart
+++ b/test/api_utils_test.dart
@@ -11,7 +11,7 @@ void main() {
   setUpAll(() {
     setHttpClientForTesting(MockClient((request) async {
       if (request.url.toString() ==
-          'https://jsonplaceholder.typicode.com/posts' &&
+              'https://jsonplaceholder.typicode.com/posts' &&
           request.method == 'GET') {
         return http.Response(
             jsonEncode([
@@ -20,7 +20,7 @@ void main() {
             ]),
             200);
       } else if (request.url.toString() ==
-          'https://jsonplaceholder.typicode.com/posts' &&
+              'https://jsonplaceholder.typicode.com/posts' &&
           request.method == 'POST') {
         return http.Response('', 201);
       } else if (request.url.toString() ==
@@ -34,10 +34,9 @@ void main() {
 
   test('getList', () async {
     var response = await getList(
-      url: 'https://jsonplaceholder.typicode.com/posts',
-      fromJson: (x) => Post.fromJson(x),
-      headers: {}
-    );
+        url: 'https://jsonplaceholder.typicode.com/posts',
+        fromJson: (x) => Post.fromJson(x),
+        headers: {});
 
     expect(response.statusCode, 200);
     expect(response.isSuccess, true);
@@ -51,10 +50,9 @@ void main() {
     });
 
     var response = await getList(
-      url: 'https://jsonplaceholder.typicode.com/posts-bad-url',
-      fromJson: (x) => Post.fromJson(x),
-      headers: {}
-    );
+        url: 'https://jsonplaceholder.typicode.com/posts-bad-url',
+        fromJson: (x) => Post.fromJson(x),
+        headers: {});
 
     expect(response.statusCode, 404);
     expect(response.isSuccess, false);
@@ -65,10 +63,9 @@ void main() {
   test('post', () async {
     var newPost = Post(title: 'title', body: 'body');
     var response = await post(
-      url: 'https://jsonplaceholder.typicode.com/posts',
-      body: newPost.toJson(),
-      headers: {}
-    );
+        url: 'https://jsonplaceholder.typicode.com/posts',
+        body: newPost.toJson(),
+        headers: {});
 
     expect(response.statusCode, 201);
     expect(response.isSuccess, true);

--- a/test/api_utils_test.dart
+++ b/test/api_utils_test.dart
@@ -10,7 +10,7 @@ void main() {
   setUpAll(() {
     setHttpClientForTesting(MockClient((request) async {
       if (request.url.toString() ==
-              'https://jsonplaceholder.typicode.com/posts' &&
+          'https://jsonplaceholder.typicode.com/posts' &&
           request.method == 'GET') {
         return http.Response(
             jsonEncode([
@@ -19,7 +19,7 @@ void main() {
             ]),
             200);
       } else if (request.url.toString() ==
-              'https://jsonplaceholder.typicode.com/posts' &&
+          'https://jsonplaceholder.typicode.com/posts' &&
           request.method == 'POST') {
         return http.Response('', 201);
       } else if (request.url.toString() ==
@@ -34,7 +34,8 @@ void main() {
   test('getList', () async {
     var response = await getList(
       url: 'https://jsonplaceholder.typicode.com/posts',
-      fromJson: (x) => Post.fromJson(x),
+      fromJson: (x) => Post.fromJson(x!),
+      headers: {}
     );
 
     expect(response.statusCode, 200);
@@ -43,14 +44,15 @@ void main() {
   });
 
   test('ApiLogger logs', () async {
-    String errorMsg;
+    String? errorMsg;
     ApiLogger.onErrorMiddleware.add((message, e, stack) {
       errorMsg = message;
     });
 
     var response = await getList(
       url: 'https://jsonplaceholder.typicode.com/posts-bad-url',
-      fromJson: (x) => Post.fromJson(x),
+      fromJson: (x) => Post.fromJson(x!),
+      headers: {}
     );
 
     expect(response.statusCode, 404);
@@ -64,6 +66,7 @@ void main() {
     var response = await post(
       url: 'https://jsonplaceholder.typicode.com/posts',
       body: newPost.toJson(),
+      headers: {}
     );
 
     expect(response.statusCode, 201);
@@ -79,10 +82,10 @@ class Post {
     this.body,
   });
 
-  final int userId;
-  final int id;
-  final String title;
-  final String body;
+  final int? userId;
+  final int? id;
+  final String? title;
+  final String? body;
 
   factory Post.fromJson(Map<String, dynamic> json) => Post(
         userId: json["userId"],


### PR DESCRIPTION
Initial migration of codebase to null-safety. The tests are set to a previous version of dart without null-safety so that it can be run successfully without the `http` plugin needing to be migrated to null-safety.

Questions:

1. The try-catch clause for async methods have slightly changed. Instead of returning an error of type `Exception` on error, it now returns an error of type `Object`. I have updated the catch clause to be `on Exception catch` to only catch exceptions so that the program can compile. Would it be a good idea to revert the catch clause to be just `catch`, and handle the `Object` error? That way, we can handle all types of general errors.

2. `ApiResponse` has a `data` property of type `T?`, since we can't guarantee that the response was successful. It would be nice to be able to guarantee that `data` is of type `T` so that a null check is not necessary anymore. One way I can think of doing that is similar to how `ValueResult` and `Result` are implemented. There could be a `SuccessApiResponse` class that holds a `data` property of type `T`. This class implements `ApiResponse` and `ApiResponse` will have a factory method that returns a `SuccessApiResponse` if the response is a success (and returns some sort of error subclass if unsuccessful). The main con with this approach is that it is a breaking change, and a check will have to made to make sure it is type `SuccessApiResponse`. Would like to know your thoughts on this.