### PR TITLE
feature: add setSentryHttpClient method to wrap client with sentry one

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -7,15 +7,14 @@ import 'package:api_utils/src/status_code.dart';
 import 'package:api_utils/src/timeout.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 @visibleForTesting
 void setHttpClientForTesting(http.Client client) {
   _client = client;
 }
 
-void setSentryHttpClient({SentryHttpClient? client}) {
-  _client = client ?? SentryHttpClient(client: http.Client());
+void setHttpClient(http.Client client) {
+  _client = client;
 }
 
 http.Client _client = http.Client();

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -1,16 +1,21 @@
-import 'dart:typed_data';
 import 'dart:convert';
+import 'dart:typed_data';
 
+import 'package:api_utils/src/api_config.dart';
+import 'package:api_utils/src/api_response.dart';
+import 'package:api_utils/src/status_code.dart';
+import 'package:api_utils/src/timeout.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-import 'package:api_utils/src/api_config.dart';
-import 'package:api_utils/src/timeout.dart';
-import 'package:api_utils/src/status_code.dart';
-import 'package:api_utils/src/api_response.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 @visibleForTesting
 void setHttpClientForTesting(http.Client client) {
   _client = client;
+}
+
+void setSentryHttpClient({SentryHttpClient? client}) {
+  _client = client ?? SentryHttpClient(client: http.Client());
 }
 
 http.Client _client = http.Client();

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -6,12 +6,6 @@ import 'package:api_utils/src/api_response.dart';
 import 'package:api_utils/src/status_code.dart';
 import 'package:api_utils/src/timeout.dart';
 import 'package:http/http.dart' as http;
-import 'package:meta/meta.dart';
-
-@visibleForTesting
-void setHttpClientForTesting(http.Client client) {
-  _client = client;
-}
 
 void setHttpClient(http.Client client) {
   _client = client;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -82,7 +82,7 @@ packages:
     source: hosted
     version: "0.12.10"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,20 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
-  convert:
-    dependency: transitive
-    description:
-      name: convert
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "3.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -85,14 +78,14 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2"
+    version: "0.13.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   js:
     dependency: transitive
     description:
@@ -141,7 +134,7 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.6"
+    version: "4.1.0-nullsafety.1"
   sentry_flutter:
     dependency: "direct main"
     description:
@@ -209,7 +202,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "3.0.4"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,13 +43,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -67,11 +60,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   http:
     dependency: "direct main"
     description:
@@ -86,13 +74,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
@@ -107,13 +88,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
-  package_info:
-    dependency: transitive
-    description:
-      name: package_info
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.3+4"
   path:
     dependency: transitive
     description:
@@ -128,20 +102,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.0"
-  sentry:
-    dependency: transitive
-    description:
-      name: sentry
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.1.0-nullsafety.1"
-  sentry_flutter:
-    dependency: "direct main"
-    description:
-      name: sentry_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.6"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -196,13 +156,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
-  uuid:
-    dependency: transitive
-    description:
-      name: uuid
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.4"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.5"
   fake_async:
     dependency: transitive
     description:
@@ -60,20 +74,32 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   http:
     dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.12.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "3.1.4"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
@@ -88,6 +114,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  package_info:
+    dependency: transitive
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.3+4"
   path:
     dependency: transitive
     description:
@@ -102,6 +135,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.0"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.6"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.6"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -156,6 +203,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 dependencies:
   http: ^0.13.0
   meta: ^1.3.0
-  sentry_flutter: ^4.0.6
 
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 
 dependencies:
   http: ^0.13.0
-  meta: ^1.3.0
 
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  http: ^0.12.2
+  http: ^0.13.0
   meta: ^1.3.0
   sentry_flutter: ^4.0.6
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,10 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  http: ^0.13.0
-  meta: '>=1.0.0 <2.0.0'
+  http: ^0.12.2
+  meta: ^1.3.0
+  sentry_flutter: ^4.0.6
+
   flutter:
     sdk: flutter
 

--- a/test/api_utils_test.dart
+++ b/test/api_utils_test.dart
@@ -1,12 +1,13 @@
 import 'dart:convert';
-import 'package:flutter_test/flutter_test.dart';
+
 import 'package:api_utils/api_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
 void main() {
   setUpAll(() {
-    setHttpClientForTesting(MockClient((request) async {
+    setHttpClient(MockClient((request) async {
       if (request.url.toString() ==
               'https://jsonplaceholder.typicode.com/posts' &&
           request.method == 'GET') {


### PR DESCRIPTION
now I introduced the new method `setSentryHttpClient` to wrap the regular http client with Sentry one.
But I am open just to make the private `_client` to be the SentryHttpClient (to reduce one extra step)